### PR TITLE
Add createThumbnail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,40 @@ VideoEditor.createThumbnail(
 )
 ```
 
+```javascript
+// this example uses the cordova media capture plugin
+navigator.device.capture.captureVideo(
+    videoCaptureSuccess, 
+    videoCaptureError, 
+    { 
+        limit: 1, 
+        duration: 20 
+    }
+);
+
+function videoCaptureSuccess(mediaFiles) {
+    var file = mediaFiles[0];
+    var videoFileName = 'video-name-here'; // I suggest a uuid
+
+    // Wrap this call in a ~100 ms timeout on Android if
+    // you just recorded the video using the capture plugin.
+    // For some reason it is not available immediately in the file system.
+    VideoEditor.createThumbnail(
+        createThumbnailSuccess,
+        createThumbnailError,
+        {
+            fileUri: mediaFile.fullPath,
+            outputFileName: videoFileName
+        }
+    )
+}
+
+function createThumbnailSuccess(result) {
+    // result is the path to the jpeg image on the device
+    console.log('createThumbnailSuccess, result: ' + result);
+}
+```
+
 ## On iOS
 
 [iOS Developer AVFoundation Documentation](https://developer.apple.com/library/ios/documentation/AudioVideo/Conceptual/AVFoundationPG/Articles/01_UsingAssets.html#//apple_ref/doc/uid/TP40010188-CH7-SW8)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ VideoEditor.transcodeVideo(
         quality: VideoEditorOptions.Quality.MEDIUM_QUALITY,
         outputFileType: VideoEditorOptions.OutputFileType.MPEG4,
         optimizeForNetworkUse: VideoEditorOptions.OptimizeForNetworkUse.YES,
-        duration: 20 // optional, specify duration in seconds from start of video
+        duration: 20, // optional, specify duration in seconds from start of video
+        saveToLibrary: true // optional, defaults to true
     }
 )
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a cordova plugin to assist in several video editing tasks such as:
 
 * Transcoding
 * Trimming
-* Taking still images from time moments (TODO)
+* Taking still images from time moments (currently the start of a video)
 
 After looking at an article on [How Vine Satisfied Its Need for Speed](http://www.technologyreview.com/view/510511/how-vine-satisfies-its-need-for-speed/), it was clear Cordova/Phonegap needed a way to modify videos to be faster for app's that need that speed.
 
@@ -88,6 +88,18 @@ function videoTranscodeError(err) {
 }
 ```
 
+###Create JPEG Image From Video###
+```javascript
+VideoEditor.createThumbnail(
+    success, // success cb
+    error, // error cb
+    {
+        fileUri: 'file-uri-here', // the path to the video on the device
+        outputFileName: 'output-name' // the file name for the JPEG image
+    }
+)
+```
+
 ## On iOS
 
 [iOS Developer AVFoundation Documentation](https://developer.apple.com/library/ios/documentation/AudioVideo/Conceptual/AVFoundationPG/Articles/01_UsingAssets.html#//apple_ref/doc/uid/TP40010188-CH7-SW8)
@@ -113,6 +125,3 @@ function videoTranscodeError(err) {
 [How to Port ffmpeg (the Program) to Android–Ideas and Thoughts](http://www.roman10.net/how-to-port-ffmpeg-the-program-to-androidideas-and-thoughts/)
 
 [How to Build Android Applications Based on FFmpeg by An Example](http://www.roman10.net/how-to-build-android-applications-based-on-ffmpeg-by-an-example/)
-
-### Other helpful tidbits:
-

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,5 +40,6 @@
         <source-file src="src/ios/VideoEditor.m" />
         <framework src="AssetsLibrary.framework" />
         <framework src="AVFoundation.framework" />
+        <framework src="MediaPlayer.framework" />
     </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="org.apache.cordova.videoeditor" version="0.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="org.apache.cordova.videoeditor" version="0.0.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>VideoEditor</name>
     <description>A plugin to assist in video editing tasks</description>
     <keywords>cordova,video,editing,transcoding,encoding</keywords>
@@ -14,6 +14,10 @@
     <js-module name="VideoEditorOptions" src="www/VideoEditorOptions.js">
         <clobbers target="VideoEditorOptions" />
     </js-module>
+
+    <engines>
+        <engine name="cordova" version=">=3.0.0" />
+    </engines>
 
     <!-- android -->
     <platform name="android">

--- a/src/ios/VideoEditor.h
+++ b/src/ios/VideoEditor.h
@@ -1,5 +1,5 @@
 //
-//	VideoEditor.h
+//  VideoEditor.h
 //
 //  Created by Josh Bavari on 01-14-2014
 //  Modified by Ross Martin on 01-29-2015
@@ -8,27 +8,29 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 #import <AssetsLibrary/ALAssetsLibrary.h>
+#import <MediaPlayer/MediaPlayer.h>
 
 #import <Cordova/CDV.h>
 
 enum CDVQualityType {
-	HighQuality = 0,
-	MediumQuality = 1,
-	LowQuality = 2,
+    HighQuality = 0,
+    MediumQuality = 1,
+    LowQuality = 2,
 };
 typedef NSUInteger CDVQualityType;
 
 enum CDVOutputFileType {
-	M4V = 0,
-	MPEG4 = 1,
-	M4A = 2,
-	QUICK_TIME = 3
+    M4V = 0,
+    MPEG4 = 1,
+    M4A = 2,
+    QUICK_TIME = 3
 };
 typedef NSUInteger CDVOutputFileType;
 
-@interface VideoEditorPlugin : CDVPlugin {
+@interface VideoEditor : CDVPlugin {
 }
 
 - (void)transcodeVideo:(CDVInvokedUrlCommand*)command;
+- (void) createThumbnail:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/VideoEditor.m
+++ b/src/ios/VideoEditor.m
@@ -77,6 +77,9 @@
             break;
     }
     
+    // remove file:// from the assetPath if it is there
+    assetPath = [[assetPath stringByReplacingOccurrencesOfString:@"file://" withString:@""] mutableCopy];
+    
     // check if the video can be saved to photo album before going further
     if (!UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(assetPath))
     {

--- a/www/VideoEditor.js
+++ b/www/VideoEditor.js
@@ -12,12 +12,10 @@ function VideoEditor() {
 }
 
 VideoEditor.prototype.transcodeVideo = function(success, error, options) {
-    // options = fileUri, outputFileName, quality, outputFileType, optimizeForNetworkUse
     exec(success, error, pluginName, 'transcodeVideo', [options]);
 };
 
 VideoEditor.prototype.createThumbnail = function(success, error, options) {
-    // options = fileUri, outputFileName
     exec(success, error, pluginName, 'createThumbnail', [options]);
 };
 

--- a/www/VideoEditor.js
+++ b/www/VideoEditor.js
@@ -16,4 +16,9 @@ VideoEditor.prototype.transcodeVideo = function(success, error, options) {
     exec(success, error, pluginName, 'transcodeVideo', [options]);
 };
 
+VideoEditor.prototype.createThumbnail = function(success, error, options) {
+    // options = fileUri, outputFileName
+    exec(success, error, pluginName, 'createThumbnail', [options]);
+};
+
 module.exports = new VideoEditor();


### PR DESCRIPTION
This PR adds the ability to take still images from time moments (currently the start of a video).  

__Additions/Changes:__

- Fixed incorrect name of VideoEditorPlugin class to VideoEditor for iOS.
- Added `createThumbnail` method to the plugin interface.
- Updated readme to show `createThumbnail` usage.