### PR TITLE
Add option to save to gallery (android).

### DIFF
--- a/src/android/VideoEditor.java
+++ b/src/android/VideoEditor.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 
 import com.netcompss.loader.LoadJNI;
 
+import android.content.ContentUris;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -29,7 +30,9 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
+import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.util.Log;
 
@@ -84,6 +87,7 @@ public class VideoEditor extends CordovaPlugin {
          quality: transcode quality
          outputFileType: output file type
          optimizeForNetworkUse: optimize for network use
+         saveToLibrary: bool - save to gallery
          */
         
         JSONObject options = args.optJSONObject(0);
@@ -127,12 +131,14 @@ public class VideoEditor extends CordovaPlugin {
         
         switch(videoQuality) {
             case LowQuality:
-                outputResolution = "144x192";
+                outputResolution = "320x320";
                 break;
             case MediumQuality:
+                outputResolution = "480x480";
+                break;
             case HighQuality:
             default:
-                outputResolution = "360x480"; 
+                outputResolution = "640x640"; 
                 break;
         }
         
@@ -147,10 +153,17 @@ public class VideoEditor extends CordovaPlugin {
         }
         final String appName = (String) (ai != null ? pm.getApplicationLabel(ai) : "Unknown");
         
-        File mediaStorageDir = new File(
-            Environment.getExternalStorageDirectory() + "/Movies",
-            appName
-        );
+        final boolean saveToLibrary = options.optBoolean("saveToLibrary", true);
+        File mediaStorageDir;
+        
+        if (saveToLibrary) {
+            mediaStorageDir = new File(
+                Environment.getExternalStorageDirectory() + "/Movies",
+                appName
+            );  
+        } else {
+            mediaStorageDir = new File(appContext.getExternalCacheDir().getPath());
+        }
         
         if (!mediaStorageDir.exists()) {
             if (!mediaStorageDir.mkdir()) {
@@ -219,17 +232,20 @@ public class VideoEditor extends CordovaPlugin {
                         callback.error("an error ocurred during transcoding");
                         return;
                     }
-                    
-                    // remove the original input file
-                    if (!inFile.delete()) {
-                        Log.d(TAG, "unable to delete in file");
+                                        
+                    // make the gallery display the new file if saving to library
+                    if (saveToLibrary) {
+                        // remove the original input file when saving to gallery
+                        // comment out or remove the delete based on your needs
+                        if (!inFile.delete()) {
+                            Log.d(TAG, "unable to delete in file");
+                        }
+                        
+                        Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                        scanIntent.setData(Uri.fromFile(inFile));
+                        scanIntent.setData(Uri.fromFile(outFile));
+                        appContext.sendBroadcast(scanIntent);
                     }
-                    
-                    // make the gallery display the new file and not the deleted one
-                    Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                    scanIntent.setData(Uri.fromFile(inFile));
-                    scanIntent.setData(Uri.fromFile(outFile));
-                    appContext.sendBroadcast(scanIntent);
                     
                     callback.success(outputFilePath);
                 } catch (Throwable e) {
@@ -273,21 +289,11 @@ public class VideoEditor extends CordovaPlugin {
             ai = null;
         }
         final String appName = (String) (ai != null ? pm.getApplicationLabel(ai) : "Unknown");
-        
-        File mediaStorageDir = new File(
-            Environment.getExternalStorageDirectory() + "/Pictures",
-            appName
-        );
-        
-        if (!mediaStorageDir.exists()) {
-            if (!mediaStorageDir.mkdir()) {
-                callback.error("Can't access or make Pictures directory");
-                return;
-            }
-        }
+                
+        File tempStoragePath = appContext.getExternalCacheDir();
         
         File outputFile =  new File(
-            mediaStorageDir.getPath(),
+            tempStoragePath.getPath(),
             "PIC_" + outputFileName + ".jpg"
         );
         
@@ -311,12 +317,7 @@ public class VideoEditor extends CordovaPlugin {
         } catch (IOException e) {
             callback.error(e.toString());
         }
-        
-        // make the gallery display the new file and not the deleted one
-        Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-        scanIntent.setData(Uri.fromFile(outputFile));
-        appContext.sendBroadcast(scanIntent);
-        
+                
         callback.success(outputFile.getAbsolutePath());   
     }
     
@@ -328,11 +329,7 @@ public class VideoEditor extends CordovaPlugin {
 
         // Handle the special case where you get an Android content:// uri.
         if (decoded.startsWith("content:")) {
-            Cursor cursor = this.cordova.getActivity().managedQuery(Uri.parse(decoded), new String[] { MediaStore.Images.Media.DATA }, null, null, null);
-            // Note: MediaStore.Images/Audio/Video.Media.DATA is always "_data"
-            int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-            cursor.moveToFirst();
-            fp = new File(cursor.getString(column_index));
+            fp = new File(getPath(this.cordova.getActivity().getApplicationContext(), Uri.parse(decoded)));
         } else {
             // Test to see if this is a valid URL first
             @SuppressWarnings("unused")
@@ -360,4 +357,134 @@ public class VideoEditor extends CordovaPlugin {
         }
         return fp;
     }
+    
+    /**
+     * Get a file path from a Uri. This will get the the path for Storage Access
+     * Framework Documents, as well as the _data field for the MediaStore and
+     * other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @author paulburke
+     */
+    public static String getPath(final Context context, final Uri uri) {
+
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+
+        // DocumentProvider
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+
+                // TODO handle non-primary volumes
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                return getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    public static String getDataColumn(Context context, Uri uri, String selection,
+            String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    public static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    public static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    public static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+    
 }


### PR DESCRIPTION
This PR gives Android video transcoding the ability to choose saving the transcoded video to the media gallery.  Devs that transcode existing videos may not want both copies on the file system.  When saving to the media gallery the original input file is removed (just like before this PR).  You can see in the `transcodeVideo` method where the input file is removed if being saved to the media gallery when `saveToLibrary` is `true`.  You can comment this out or remove it if you never want to remove the original input file.

In addition to this feature there are a few improvements and changes:
- The `fileUri` parameter to `transcodeVideo` now handles `content://` URIs.  You will most likely encounter `content://` URIs when choosing existing videos from the media gallery on Android.
- The arbitrary resolution qualities have been updated on Android.  `LowQuality` = `320x320`, `MediumQuality` = `480x480`, `HighQuality` = `640x640` - Width X Height.  Adjust these values based on your needs.
- The `createThumbnail` method no longer saves the JPEG image to the media gallery but rather to the temporary storage directory for your app.