### PR TITLE
Fix orientation for get video info on android

### DIFF
--- a/src/android/CustomAndroidFormatStrategy.java
+++ b/src/android/CustomAndroidFormatStrategy.java
@@ -18,27 +18,23 @@ public class CustomAndroidFormatStrategy implements MediaFormatStrategy {
     private static final int DEFAULT_FRAMERATE = 30;
     private static final int DEFAULT_WIDTH = 0;
     private static final int DEFAULT_HEIGHT = 0;
-    private static final String DEFAULT_ORIENTATION = "portrait";
     private final int mBitRate;
     private final int mFrameRate;
     private final int width;
     private final int height;
-    private final String orientation;
 
     public CustomAndroidFormatStrategy() {
         this.mBitRate = DEFAULT_BITRATE;
         this.mFrameRate = DEFAULT_FRAMERATE;
         this.width = DEFAULT_WIDTH;
         this.height = DEFAULT_HEIGHT;
-        this.orientation = DEFAULT_ORIENTATION;
     }
 
-    public CustomAndroidFormatStrategy(final int bitRate, final int frameRate, final int width, final int height, final String orientation) {
+    public CustomAndroidFormatStrategy(final int bitRate, final int frameRate, final int width, final int height) {
         this.mBitRate = bitRate;
         this.mFrameRate = frameRate;
         this.width = width;
         this.height = height;
-        this.orientation = orientation;
     }
 
     public MediaFormat createVideoOutputFormat(MediaFormat inputFormat) {
@@ -48,15 +44,10 @@ public class CustomAndroidFormatStrategy implements MediaFormatStrategy {
         int outHeight;
 
         if (this.width > 0 || this.height > 0) {
-            if (this.orientation == "portrait" && videoWidth > videoHeight) {
-                videoWidth = inputFormat.getInteger("height");
-                videoHeight = inputFormat.getInteger("width");
-            }
             double aspectRatio = (double) videoWidth / (double) videoHeight;
-
             outWidth = Double.valueOf(this.height * aspectRatio).intValue();
             outHeight = Double.valueOf(outWidth / aspectRatio).intValue();
-        } else {
+          } else {
             outWidth = videoWidth;
             outHeight = videoHeight;
         }

--- a/src/android/VideoEditor.java
+++ b/src/android/VideoEditor.java
@@ -458,7 +458,7 @@ public class VideoEditor extends CordovaPlugin {
                     orientation = "portrait";
                 }
             }
-} else {
+        } else {
             orientation = (videoWidth < videoHeight) ? "portrait" : "landscape";
         }
 

--- a/src/android/VideoEditor.java
+++ b/src/android/VideoEditor.java
@@ -236,10 +236,18 @@ public class VideoEditor extends CordovaPlugin {
                     String mmrOrientation = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION);
                     Log.d(TAG, "mmrOrientation: " + mmrOrientation); // 0, 90, 180, or 270
 
-                    if (mmrOrientation == "0" || mmrOrientation == "180") {
-                        orientation = "portrait";
+                    if (videoWidth < videoHeight) {
+                        if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
+                            orientation = "portrait";
+                        } else {
+                            orientation = "landscape";
+                        }
                     } else {
-                        orientation = "landscape";
+                        if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
+                            orientation = "landscape";
+                        } else {
+                            orientation = "portrait";
+                        }
                     }
 
                     MediaTranscoder.getInstance().transcodeVideo(fin.getFD(), outputFilePath,

--- a/src/android/VideoEditor.java
+++ b/src/android/VideoEditor.java
@@ -238,22 +238,9 @@ public class VideoEditor extends CordovaPlugin {
 
                     float videoWidth = Float.parseFloat(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH));
                     float videoHeight = Float.parseFloat(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT));
-                    if (videoWidth < videoHeight) {
-                        if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
-                            orientation = "portrait";
-                        } else {
-                            orientation = "landscape";
-                        }
-                    } else {
-                        if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
-                            orientation = "landscape";
-                        } else {
-                            orientation = "portrait";
-                        }
-                    }
 
                     MediaTranscoder.getInstance().transcodeVideo(fin.getFD(), outputFilePath,
-                            new CustomAndroidFormatStrategy(videoBitrate, fps, width, height, orientation), listener, videoDuration);
+                            new CustomAndroidFormatStrategy(videoBitrate, fps, width, height), listener, videoDuration);
 
                 } catch (Throwable e) {
                     Log.d(TAG, "transcode exception ", e);

--- a/src/android/VideoEditor.java
+++ b/src/android/VideoEditor.java
@@ -236,6 +236,8 @@ public class VideoEditor extends CordovaPlugin {
                     String mmrOrientation = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION);
                     Log.d(TAG, "mmrOrientation: " + mmrOrientation); // 0, 90, 180, or 270
 
+                    float videoWidth = Float.parseFloat(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH));
+                    float videoHeight = Float.parseFloat(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT));
                     if (videoWidth < videoHeight) {
                         if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
                             orientation = "portrait";
@@ -443,12 +445,20 @@ public class VideoEditor extends CordovaPlugin {
             String mmrOrientation = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION);
             Log.d(TAG, "mmrOrientation: " + mmrOrientation); // 0, 90, 180, or 270
 
-            if (mmrOrientation == "0" || mmrOrientation == "180") {
-                orientation = "portrait";
+            if (videoWidth < videoHeight) {
+                if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
+                    orientation = "portrait";
+                } else {
+                    orientation = "landscape";
+                }
             } else {
-                orientation = "landscape";
+                if (mmrOrientation.equals("0") || mmrOrientation.equals("180")) {
+                    orientation = "landscape";
+                } else {
+                    orientation = "portrait";
+                }
             }
-        } else {
+} else {
             orientation = (videoWidth < videoHeight) ? "portrait" : "landscape";
         }
 


### PR DESCRIPTION
GetVideoInfo was always returning landscape due to some minor bugs in Java string compares.  I saw the same pattern of code used in the orientation code in the transcode.  It turns out the way the code was it was always defaulting to landscape and was working fine so I just took out the orientation code for transcode so it would not be confusing.