### PR TITLE
exception messages showing url & file path

### DIFF
--- a/src/android/VideoEditor.java
+++ b/src/android/VideoEditor.java
@@ -493,10 +493,10 @@ public class VideoEditor extends CordovaPlugin {
         }
 
         if (!fp.exists()) {
-            throw new FileNotFoundException();
+            throw new FileNotFoundException( "" + url + " -> " + fp.getCanonicalPath());
         }
         if (!fp.canRead()) {
-            throw new IOException();
+            throw new IOException("can't read file: " + url + " -> " + fp.getCanonicalPath());
         }
         return fp;
     }


### PR DESCRIPTION
this PR includes details of supplied urls and resolved file paths in exception messages

it made problems with android marshmallow permission requests, or lack thereof, much easier to debug