### PR TITLE
iOS: Some videos end up with black background and only audio

### DIFF
--- a/src/ios/SDAVAssetExportSession.m
+++ b/src/ios/SDAVAssetExportSession.m
@@ -309,6 +309,11 @@
     CGSize targetSize = CGSizeMake([self.videoSettings[AVVideoWidthKey] floatValue], [self.videoSettings[AVVideoHeightKey] floatValue]);
     CGSize naturalSize = [videoTrack naturalSize];
     CGAffineTransform transform = videoTrack.preferredTransform;
+    CGRect rect = {{0, 0}, naturalSize};
+    CGRect transformedRect = CGRectApplyAffineTransform(rect, transform);
+    // transformedRect should have origin at 0 if correct; otherwise add offset to correct it
+    transform.tx -= transformedRect.origin.x;
+    transform.ty -= transformedRect.origin.y;
     CGFloat videoAngleInDegree  = atan2(transform.b, transform.a) * 180 / M_PI;
     if (videoAngleInDegree == 90 || videoAngleInDegree == -90) {
         CGFloat width = naturalSize.width;


### PR DESCRIPTION
Videos with rotated tracks are processed wrong and end up with video track out of viewport box. This fixes the problem.

See https://github.com/rs/SDAVAssetExportSession/issues/79#issuecomment-347718282

If you need a file to test it, let me know.